### PR TITLE
Support AppCenter download Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # App Center Github Action
 
-![Sample workflow for App Center action](https://github.com/wzieba/AppCenter-Github-Action/workflows/Sample%20workflow%20for%20App%20Center%20action/badge.svg?branch=master)
-<a href="https://github.com/wzieba/AppCenter-Github-Action/releases">![](https://img.shields.io/github/v/release/wzieba/AppCenter-Github-Action)</a>
+![Sample workflow for App Center action](https://github.com/devussy/AppCenter-Distribute-Github-Action/workflows/Sample%20workflow%20for%20App%20Center%20action/badge.svg?branch=master)
+<a href="https://github.com/devussy/AppCenter-Distribute-Github-Action/releases">![](https://img.shields.io/github/v/release/devussy/AppCenter-Distribute-Github-Action)</a>
 
 This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 
@@ -9,7 +9,7 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 
 ### `appName`
 
-**Required** username followed by App name e.g. `wzieba/Sample-App`
+**Required** username followed by App name e.g. `devussy/Sample-App`
 
 ### `token`
 
@@ -24,9 +24,11 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 **Required** Artifact to upload (.apk or .ipa)
 
 ### `buildVersion`
+
 Build version parameter required for .zip, .msi, .pkg and .dmg files
 
 ### buildNumber
+
 Build number parameter required for macOS .pkg and .dmg files
 
 ### `releaseNotes`
@@ -71,9 +73,9 @@ jobs:
     - name: build release
       run: ./gradlew assembleRelease
     - name: upload artefact to App Center
-      uses: wzieba/AppCenter-Github-Action@v1
+      uses: devussy/AppCenter-Distribute-Github-Action@v1.0.3
       with:
-        appName: wzieba/Sample-App
+        appName: devussy/Sample-App
         token: ${{secrets.APP_CENTER_TOKEN}}
         group: Testers
         file: app/build/outputs/apk/release/app-release-unsigned.apk

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: "App Center Distribute"
 description: "GitHub Action that uploads artefacts for Visual Studio App Center"
-author: "Wojciech Zięba <@wzieba>"
+author: "Seungyong Yun <@devussy>"
 inputs:
   appName:
-    description: "App name followed by username e.g. wzieba/Sample-App"
+    description: "App name followed by username e.g. devussy/Sample-App"
     required: true
   token:
     description: "Upload token - you can get one from appcenter.ms/settings"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,9 @@ for group in $INPUT_GROUP; do
         isFirst=false
         appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$RELEASE_NOTES" "${params[@]}"
         releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | tr -s ' ' | cut -f2 -d ' ' | sort -n -r | head -1)
-        downloadUrl=$(appcenter distribute releases show --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep Download URL | tr -s ' ' | cut -f2 -d ' ' | sort -n -r | head -1)
+        downloadUrl=$(appcenter distribute releases show --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" --release-id "$releaseId" --output json | grep -o '"[^"]*"\s*:\s*"[^"]*"' | grep -E '^"downloadUrl"' | cut  -d ':' -f 2,3 | tr -d '"')
         
-        echo "appcenter_download_link=$downloadUrl" >> "$GITHUB_ENV"
+        echo "APPCENTER_DOWNLOAD_LINK=$downloadUrl" >> "$GITHUB_ENV"
     else
         appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId --app "$INPUT_APPNAME" "${params[@]}"
     fi


### PR DESCRIPTION
* There is a demand to utilize the `AppCenter download Url` , so add logic to support it.
* #1 PR has a issue to parse downloadUrl. Fix it.